### PR TITLE
Properly implement column relocation, and use it in RotateEditTask

### DIFF
--- a/src/main/java/cubicchunks/converter/lib/convert/cc2ccrelocating/CC2CCRelocatingDataConverter.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/cc2ccrelocating/CC2CCRelocatingDataConverter.java
@@ -132,7 +132,7 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
         ImmutablePair<Long, CompoundTag> inColumnData;
         try {
             ImmutablePair<Long, ByteBuffer> data = input.getColumnData();
-            if (data != null) {
+            if (data != null && data.getValue() != null) {
                 inColumnData = new ImmutablePair<>(
                         data.getKey(),
                         readCompressedCC(new ByteArrayInputStream(data.getValue().array()))
@@ -245,8 +245,8 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
 
         Map<Vector2i, ImmutablePair<Long, CompoundTag>> tagMap = new HashMap<>();
 
-        int columnX = (Integer) level.get("xPos").getValue();
-        int columnZ = (Integer) level.get("zPos").getValue();
+        int columnX = (Integer) level.get("x").getValue();
+        int columnZ = (Integer) level.get("z").getValue();
 
         for (EditTask task : this.relocateTasks) {
             if (!task.handlesDimension(dimension.getDirectory())) {

--- a/src/main/java/cubicchunks/converter/lib/convert/cc2ccrelocating/CC2CCRelocatingDataConverter.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/cc2ccrelocating/CC2CCRelocatingDataConverter.java
@@ -32,12 +32,12 @@ import cubicchunks.converter.lib.convert.ChunkDataConverter;
 import cubicchunks.converter.lib.convert.data.PriorityCubicChunksColumnData;
 import cubicchunks.converter.lib.util.*;
 import cubicchunks.converter.lib.util.edittask.EditTask;
-import cubicchunks.converter.lib.util.edittask.RotateEditTask;
 import cubicchunks.regionlib.impl.EntryLocation2D;
-import javafx.scene.transform.Rotate;
 
+import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -89,22 +89,15 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
     @Override public Set<PriorityCubicChunksColumnData> convert(PriorityCubicChunksColumnData input) {
         Map<Integer, ImmutablePair<Long, ByteBuffer>> inCubes = input.getCubeData();
         Map<Integer, ImmutablePair<Long, ByteBuffer>> cubes = new HashMap<>();
-        boolean hasRotateEditTask = false;
 
         //Split out cubes that are only in a keep tasked bounding box
         Map<Integer, ImmutablePair<Long, ByteBuffer>> noReadCubes = new HashMap<>();
         EntryLocation2D inPosition = input.getPosition();
-        EntryLocation2D rotatedInPosition = null;
         for(Map.Entry<Integer, ImmutablePair<Long, ByteBuffer>> entry : inCubes.entrySet()) {
             boolean anyBoxNeedsData = false;
             boolean intersectsSrcBox = false;
 
-            //TODO cleanup code
             for(EditTask task : relocateTasks) {
-                if (task instanceof RotateEditTask) {
-                    hasRotateEditTask = true;
-                    rotatedInPosition = ((RotateEditTask) task).rotateDstEntryLocation(inPosition);
-                }
                 List<BoundingBox> srcBoxes = task.getSrcBoxes();
                 for (BoundingBox srcBox : srcBoxes) {
                     if(srcBox.intersects(inPosition.getEntryX(), entry.getKey(), inPosition.getEntryZ())) {
@@ -125,6 +118,7 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
                 noReadCubes.put(entry.getKey(), entry.getValue());
         }
 
+        // Decompress data into tags
         Map<Integer, ImmutablePair<Long, CompoundTag>> inCubeData = new HashMap<>();
         cubes.forEach((key, value) -> {
             try {
@@ -134,34 +128,43 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
             }
         });
 
+        ImmutablePair<Long, CompoundTag> inColumnData;
+        try {
+            inColumnData = new ImmutablePair<>(
+                    input.getColumnData().getKey(),
+                    readCompressedCC(new ByteArrayInputStream(input.getColumnData().getValue().array()))
+            );
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
         try {
             Map<Vector2i, Map<Integer, ImmutablePair<Long, CompoundTag>>> outCubeData = relocateCubeData(input.getDimension(), inCubeData, this.config);
+            Map<Vector2i, ImmutablePair<Long, CompoundTag>> outColumnData = relocateColumnData(input.getDimension(), inColumnData, this.config);
 
-            if (hasRotateEditTask){
-                inPosition = rotatedInPosition;
-                if (input.getColumnData() != null){
-                    CompoundTag inputTag = readCompressedCC(new ByteArrayInputStream(input.getColumnData().array()));
-                    CompoundMap level = (CompoundMap) inputTag.getValue().get("Level").getValue();
-                    level.put(new IntTag("x", inPosition.getEntryX()));
-                    level.put(new IntTag("z", inPosition.getEntryZ()));
-                    input = new PriorityCubicChunksColumnData(input.getDimension(), inPosition ,Utils.writeCompressed(inputTag, false), input.getCubeData(), true);
+            Map<Vector2i, ImmutablePair<Long, ByteBuffer>> compressedColumns = new HashMap<>();
+            outColumnData.forEach((columnPos, columnTag) -> {
+                try {
+                    compressedColumns.put(columnPos, new ImmutablePair<>(columnTag.getKey(), Utils.writeCompressed(columnTag.getValue(), false)));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
                 }
-            }
+            });
 
             Set<PriorityCubicChunksColumnData> columnData = new HashSet<>();
             for (Map.Entry<Vector2i, Map<Integer, ImmutablePair<Long, CompoundTag>>> entry : outCubeData.entrySet()) {
                 Vector2i key = entry.getKey();
-                ByteBuffer column = key.getX() != inPosition.getEntryX() || key.getY() != inPosition.getEntryZ() ? null : input.getColumnData();
+                ImmutablePair<Long, ByteBuffer> column = compressedColumns.get(key);
 
                 EntryLocation2D location = new EntryLocation2D(key.getX(), key.getY());
                 columnData.add(new PriorityCubicChunksColumnData(input.getDimension(), location, column, compressCubeData(entry.getValue()), true));
             }
+
+            // Merge cubes with no operation back into the final output data
             if (!noReadCubes.isEmpty()) {
-                EntryLocation2D finalInPosition = inPosition;
-                PriorityCubicChunksColumnData finalInput = input;
                 PriorityCubicChunksColumnData currentColumnData = columnData.stream()
-                        .filter(column -> column.getPosition().equals(finalInPosition)).findAny()
-                        .orElseGet(() -> new PriorityCubicChunksColumnData(finalInput.getDimension(), finalInPosition, finalInput.getColumnData(), new HashMap<>(), true));
+                        .filter(column -> column.getPosition().equals(inPosition)).findAny()
+                        .orElseGet(() -> new PriorityCubicChunksColumnData(input.getDimension(), inPosition, input.getColumnData(), new HashMap<>(), true));
                 noReadCubes.forEach((yPos, buffer) -> currentColumnData.getCubeData().putIfAbsent(yPos, buffer));
                 columnData.add(currentColumnData);
             }
@@ -209,7 +212,8 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
                 if(!cubeIsSrc)
                     continue;
 
-                List<ImmutablePair<Vector3i, ImmutablePair<Long, CompoundTag>>> outputCubes = task.actOnCube(new Vector3i(cubeX, cubeY, cubeZ), config, entry.getValue().getValue(), entry.getKey());
+                List<ImmutablePair<Vector3i, ImmutablePair<Long, CompoundTag>>> outputCubes =
+                        task.actOnCube(new Vector3i(cubeX, cubeY, cubeZ), config, entry.getValue().getValue(), entry.getKey());
 
                 outputCubes.forEach(positionTagPriority -> {
                     Vector3i cubePos = positionTagPriority.getKey();
@@ -222,6 +226,49 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
             }
         }
 
+        return tagMap;
+    }
+
+    @Nonnull
+    private Map<Vector2i, ImmutablePair<Long, CompoundTag>> relocateColumnData(Dimension dimension, ImmutablePair<Long, CompoundTag> columnData, EditTaskContext.EditTaskConfig config) {
+        CompoundMap level = (CompoundMap)columnData.getValue().getValue().get("Level").getValue();
+
+        Map<Vector2i, ImmutablePair<Long, CompoundTag>> tagMap = new HashMap<>();
+
+        int columnX = (Integer) level.get("xPos").getValue();
+        int columnZ = (Integer) level.get("zPos").getValue();
+
+        for (EditTask task : this.relocateTasks) {
+            if (!task.handlesDimension(dimension.getDirectory())) {
+                continue;
+            }
+            task.initialise(config);
+            if (!task.readsCubeData()) {
+                continue;
+            }
+
+            boolean cubeIsSrc = false;
+            for (BoundingBox sourceBox : task.getSrcBoxes()) {
+                if (sourceBox.columnIntersects(columnX, columnZ)) {
+                    cubeIsSrc = true;
+                    break;
+                }
+            }
+            if (!cubeIsSrc)
+                continue;
+
+            List<ImmutablePair<Vector2i, ImmutablePair<Long, CompoundTag>>> outputColumns =
+                    task.actOnColumn(new Vector2i(columnX, columnZ), config, columnData.getValue(), columnData.getKey());
+
+            outputColumns.forEach(positionTagPriority -> {
+                Vector2i columnPos = positionTagPriority.getKey();
+                ImmutablePair<Long, CompoundTag> tagPriority = positionTagPriority.getValue();
+                if(tagPriority.getValue() == null)
+                    tagMap.remove(columnPos);
+                else
+                    tagMap.put(columnPos, tagPriority);
+            });
+        }
         return tagMap;
     }
 }

--- a/src/main/java/cubicchunks/converter/lib/convert/cc2ccrelocating/CC2CCRelocatingDataConverter.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/cc2ccrelocating/CC2CCRelocatingDataConverter.java
@@ -35,6 +35,7 @@ import cubicchunks.converter.lib.util.edittask.EditTask;
 import cubicchunks.regionlib.impl.EntryLocation2D;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -130,10 +131,15 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
 
         ImmutablePair<Long, CompoundTag> inColumnData;
         try {
-            inColumnData = new ImmutablePair<>(
-                    input.getColumnData().getKey(),
-                    readCompressedCC(new ByteArrayInputStream(input.getColumnData().getValue().array()))
-            );
+            ImmutablePair<Long, ByteBuffer> data = input.getColumnData();
+            if (data != null) {
+                inColumnData = new ImmutablePair<>(
+                        data.getKey(),
+                        readCompressedCC(new ByteArrayInputStream(data.getValue().array()))
+                );
+            } else {
+                inColumnData = null;
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -230,7 +236,11 @@ public class CC2CCRelocatingDataConverter implements ChunkDataConverter<Priority
     }
 
     @Nonnull
-    private Map<Vector2i, ImmutablePair<Long, CompoundTag>> relocateColumnData(Dimension dimension, ImmutablePair<Long, CompoundTag> columnData, EditTaskContext.EditTaskConfig config) {
+    private Map<Vector2i, ImmutablePair<Long, CompoundTag>> relocateColumnData(Dimension dimension, @Nullable ImmutablePair<Long, CompoundTag> columnData, EditTaskContext.EditTaskConfig config) {
+        if (columnData == null) {
+            return new HashMap<>();
+        }
+
         CompoundMap level = (CompoundMap)columnData.getValue().getValue().get("Level").getValue();
 
         Map<Vector2i, ImmutablePair<Long, CompoundTag>> tagMap = new HashMap<>();

--- a/src/main/java/cubicchunks/converter/lib/convert/data/PriorityCubicChunksColumnData.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/data/PriorityCubicChunksColumnData.java
@@ -33,12 +33,12 @@ import java.util.Map;
 public class PriorityCubicChunksColumnData {
     private final Dimension dimension;
     private final EntryLocation2D position;
-    private final ByteBuffer columnData;
+    private final ImmutablePair<Long, ByteBuffer> columnData;
     private final Map<Integer, ImmutablePair<Long, ByteBuffer>> cubeData;
 
     private final boolean isCompressed;
 
-    public PriorityCubicChunksColumnData(Dimension dimension, EntryLocation2D position, ByteBuffer columnData,
+    public PriorityCubicChunksColumnData(Dimension dimension, EntryLocation2D position, ImmutablePair<Long, ByteBuffer> columnData,
                                          Map<Integer, ImmutablePair<Long, ByteBuffer>> cubeData, boolean isCompressed) {
         this.dimension = dimension;
         this.position = position;
@@ -55,7 +55,7 @@ public class PriorityCubicChunksColumnData {
         return position;
     }
 
-    public ByteBuffer getColumnData() {
+    public ImmutablePair<Long, ByteBuffer> getColumnData() {
         return columnData;
     }
 

--- a/src/main/java/cubicchunks/converter/lib/convert/io/PriorityCubicChunkReader.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/io/PriorityCubicChunkReader.java
@@ -250,7 +250,7 @@ public class PriorityCubicChunkReader extends BaseMinecraftReader<PriorityCubicC
                         ByteBuffer cube = save.load(location, true).orElse(Utils.createAirCubeBuffer(location));
                         cubes.put(y, new ImmutablePair<>(0L, cube));
                     }
-                    PriorityCubicChunksColumnData data = new PriorityCubicChunksColumnData(dim, pos2d, column, cubes, true);
+                    PriorityCubicChunksColumnData data = new PriorityCubicChunksColumnData(dim, pos2d, new ImmutablePair<>(0L, column), cubes, true);
                     consumer.accept(data);
                 } catch (IOException ex) {
                     throw new UncheckedIOException(ex);

--- a/src/main/java/cubicchunks/converter/lib/convert/io/PriorityCubicChunkWriter.java
+++ b/src/main/java/cubicchunks/converter/lib/convert/io/PriorityCubicChunkWriter.java
@@ -53,6 +53,7 @@ public class PriorityCubicChunkWriter implements ChunkDataWriter<PriorityCubicCh
         this.dstPath = dstPath;
     }
 
+    private Map<Vector2i, Long> columnPriorities = new HashMap<>();
     private Map<Vector3i, Long> cubePriorities = new HashMap<>();
 
     @Override public void accept(PriorityCubicChunksColumnData data) throws IOException {
@@ -111,8 +112,14 @@ public class PriorityCubicChunkWriter implements ChunkDataWriter<PriorityCubicCh
             }
         });
         EntryLocation2D pos = data.getPosition();
-        if (data.getColumnData() != null) {
-            save.save2d(pos, data.getColumnData());
+        ImmutablePair<Long, ByteBuffer> columnData = data.getColumnData();
+        if (columnData != null) {
+            Vector2i columnPos = new Vector2i(pos.getEntryX(), pos.getEntryZ());
+            Long priority = columnPriorities.get(columnPos);
+            if(priority == null || columnData.getFirst() > priority) {
+                columnPriorities.put(columnPos, columnData.getKey());
+                save.save2d(new EntryLocation2D(pos.getEntryX(), pos.getEntryZ()), columnData.getValue());
+            }
         }
         EntryLocation2D entryPos = data.getPosition();
         for (Map.Entry<Integer, ImmutablePair<Long, ByteBuffer>> entry : data.getCubeData().entrySet()) {

--- a/src/main/java/cubicchunks/converter/lib/util/edittask/EditTask.java
+++ b/src/main/java/cubicchunks/converter/lib/util/edittask/EditTask.java
@@ -28,10 +28,12 @@ import com.flowpowered.nbt.CompoundTag;
 import cubicchunks.converter.lib.conf.command.EditTaskContext;
 import cubicchunks.converter.lib.util.BoundingBox;
 import cubicchunks.converter.lib.util.ImmutablePair;
+import cubicchunks.converter.lib.util.Vector2i;
 import cubicchunks.converter.lib.util.Vector3i;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public interface EditTask {
@@ -40,6 +42,16 @@ public interface EditTask {
      * @return The modified cube/s. The {@link CompoundMap} can be null, if so the cube will be regenerated the next time it's loaded by the game
      */
     @Nonnull List<ImmutablePair<Vector3i, ImmutablePair<Long, CompoundTag>>> actOnCube(Vector3i cubePos, EditTaskContext.EditTaskConfig config, CompoundTag cubeTag, long inCubePriority);
+
+    /**
+     * @param columnTag The column to be modified. The {@link Vector2i} is in chunk coordinates, not block
+     * @return The modified column/s. The {@link CompoundMap} can be null, if so the column will be regenerated the next time it's loaded by the game
+     *
+     * The default behaviour is to just return the column unchanged.
+     */
+    @Nonnull default List<ImmutablePair<Vector2i, ImmutablePair<Long, CompoundTag>>> actOnColumn(Vector2i columnPos, EditTaskContext.EditTaskConfig config, CompoundTag columnTag, long inColumnPriority) {
+        return Collections.singletonList(new ImmutablePair<>(columnPos, new ImmutablePair<>(inColumnPriority, columnTag)));
+    }
 
     // TODO: have each task actually specify dimensions somehow
     default boolean handlesDimension(String directoryName) {

--- a/src/main/java/cubicchunks/converter/lib/util/edittask/RotateEditTask.java
+++ b/src/main/java/cubicchunks/converter/lib/util/edittask/RotateEditTask.java
@@ -727,8 +727,8 @@ public class RotateEditTask extends TranslationEditTask {
         byte[] newBlocks = new byte[blocks.length];
         byte[] newMeta = new byte[meta.length];
 
-        int sideLen=16;
-        int squareLen=sideLen*sideLen;
+        int sideLen = 16;
+        int squareLen = sideLen * sideLen;
 
         for (int y = 0; y < blocks.length / squareLen; y++) {
             for (int r = 0; r < sideLen; r++) {
@@ -793,6 +793,19 @@ public class RotateEditTask extends TranslationEditTask {
         return outCubes;
     }
 
+    @Nonnull
+    @Override
+    public List<ImmutablePair<Vector2i, ImmutablePair<Long, CompoundTag>>> actOnColumn(Vector2i columnPos, EditTaskContext.EditTaskConfig config, CompoundTag columnTag, long inColumnPriority) {
+        List<ImmutablePair<Vector2i, ImmutablePair<Long, CompoundTag>>> outColumns = new ArrayList<>();
+
+        Vector2i outPosition = this.rotateDst(columnPos, this.degrees);
+        CompoundMap level = (CompoundMap) columnTag.getValue().get("Level").getValue();
+        level.put(new IntTag("x", outPosition.getX()));
+        level.put(new IntTag("z", outPosition.getY()));
+
+        outColumns.add(new ImmutablePair<>(outPosition, new ImmutablePair<>(inColumnPriority + 1, columnTag)));
+        return outColumns;
+    }
 }
 
 


### PR DESCRIPTION
Please note that this PR is untested as I saw bukkit APIs were added to this fork and decided it wasn't worth the effort of setting it up without some guidance.

Previously RotateEditTask had hard-coded jank throughout the data-converter, this commit aims to fully separate the two.

To do this a new `EditTask#actOnColumn` api was added, which allows an implementation to output any number of columns at any position.

The cubes output by EditTask#actOnCube will attempt to use a column in their position if it exists.